### PR TITLE
Add command line option to produce input and output suitable for directly feeding to the uPrint 'er' and 'ew' diagnostic commands.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,14 @@ The EEPROM uid should end with '23'. You may have to reverse the byte order. Say
 If you provide the '-r' option, arguments to pass to stratasys-cli will be printed
 to help you recreate the cartridge.
 
-The input file must be a binary file.
+If you provide the '-D' option, the input file will be interpreted as an ASCII formatted file,
+containing lines of the form produced by the printers 'er' command, namely:
+
+```
+000096: 00 00 00 00 00 00 00 00 53 54 52 41 54 41 53 59   ........STRATASY
+```
+
+Otherwise, the input file must be a binary file.
 
 ### Create your own cartridge
 
@@ -50,7 +57,10 @@ The EEPROM uid use to end with '23'. You may have to reverse it. Say you have
 `233a38b1020000c0`, you should reverse it to be `c0000002b1383a23`.
 
 The generated file will be 113 bytes in size. You can complete the file with zeroes
-if you want to make it 512 bytes long, the usual EEPROM size.
+if you want to make it 512 bytes long, the usual EEPROM size.a
+
+Supplying the '-D' option will result in an output file containing a double-quoted string
+of space delimited bytes, expressed in hexadecimal. Otherwise, the output will be a binary file.
 
 ### List supported material
 

--- a/stratasys/formatter.py
+++ b/stratasys/formatter.py
@@ -41,6 +41,6 @@ class DiagnosticPort_Formatter(Formatter):
         formatted = "\""
 
         for b in data:
-            formatted += binascii.hexlify(b) + " "
+            formatted += binascii.hexlify(chr(b)) + " "
 
         return formatted[0:-1] + "\""

--- a/stratasys/formatter.py
+++ b/stratasys/formatter.py
@@ -18,6 +18,9 @@ class DiagnosticPort_Formatter(Formatter):
     def __init__(self):
         self.rx = re.compile('^[0-9]{6}: ((?:[0-9a-f-A-F]{2} ?)+).*?$',re.MULTILINE)
 
+#Reads a series of newline delimited lines of the format:
+#000096: 00 00 00 00 00 00 00 00 53 54 52 41 54 41 53 59   ........STRATASY
+
     def from_source(self, data):
         formatted = b''
         idx = 1
@@ -33,6 +36,7 @@ class DiagnosticPort_Formatter(Formatter):
 
         return formatted
 
+#Produces a double-quoted, space separated string suitable for providing to the uPrint's 'ew' diagnostic command
     def to_destination(self, data):
         formatted = "\""
 

--- a/stratasys/formatter.py
+++ b/stratasys/formatter.py
@@ -1,6 +1,8 @@
 #
 # See the LICENSE file
 #
+import re
+import binascii
 
 class Formatter:
     def __init__(self):
@@ -14,19 +16,27 @@ class Formatter:
 
 class DiagnosticPort_Formatter(Formatter):
     def __init__(self):
-        pass
+        self.rx = re.compile('^[0-9]{6}: ((?:[0-9a-f-A-F]{2} ?)+).*?$',re.MULTILINE)
 
     def from_source(self, data):
-        formatted = ""
-
-        # TODO - implements me
+        formatted = b''
+        idx = 1
+        for match in self.rx.finditer(data):
+            try:
+                #Get a line of data with whitespace removed
+                line = match.group(1).replace(' ', '')
+                formatted += binascii.unhexlify(line)
+                idx=idx+1
+            except IndexError:
+                print("Error on line %s when reading diag port formatted data" % (idx,))
+                raise
 
         return formatted
 
     def to_destination(self, data):
-        formatted = ""
+        formatted = "\""
 
         for b in data:
-            formatted += binascii.hexlify(b) + ", "
+            formatted += binascii.hexlify(b) + " "
 
-        return formatted[0:-2]
+        return formatted[0:-1] + "\""


### PR DESCRIPTION
I have finished implementing the incomplete DiagnosticPort_Formatter class and used such to add a new, optional command line argument, '-D', that allows input and output to be read and written in the format produced by the EEPROM read and write diagnostic commands on a uPrint. This  allows for easy reading and writing of material cartridges in the machine. Finally, this change has been documented in the readme as well as via the addition of code comments.